### PR TITLE
Add job, remove custom command

### DIFF
--- a/orb-setup-scripts/create-namespace.sh
+++ b/orb-setup-scripts/create-namespace.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# run like this:
-# bash create-namespace.sh your-namespace your-github-org
-# e.g., bash create-namespace.sh test-namespace test-org
-# to create the namespace, you must have owner/admin privileges in the github org
-
-circleci namespace create "$1" github "$2"

--- a/orb-setup-scripts/create-orb.sh
+++ b/orb-setup-scripts/create-orb.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# run like this:
-# bash create-orb.sh your-namespace/your-orb-name
-
-circleci orb create "$1"

--- a/orb-setup-scripts/install-cli.sh
+++ b/orb-setup-scripts/install-cli.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-curl -fLSs https://circle.ci/cli | sudo bash && circleci setup

--- a/orb.yml
+++ b/orb.yml
@@ -4,7 +4,8 @@ version: 2.1
 
 description: |
   This orb integrates open source licensing compliance and vulnerability checks into your CI/CD workflow.
-  Source: https://github.com/fossas/fossa-cli-orb
+  Source - https://github.com/fossas/fossa-cli-orb
+  Docs - https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#cli-reference
 
 examples:
   analyze_job:

--- a/orb.yml
+++ b/orb.yml
@@ -7,37 +7,74 @@ description: |
   Source: https://github.com/fossas/fossa-cli-orb
 
 examples:
-  standard_fossa_usage:
+  analyze_job:
     description: |
-      If you have a standard CircleCI configuration file, you can simply add this
-      orb and then run fossa-cli/setup to streamline open source compliance.
+      Analyze a project from within your workflow automatically.
     usage:
       version: 2.1
-
       orbs:
-        fossa-cli: fossa/cli@dev:alpha
-
+        fossa-cli: fossa/cli@x.y.z
       workflows:
         fossa-integration:
           jobs:
+            - fossa-cli/analyze:
+                post-steps:
+                  - run: # run more commands if desired
+
+  custom_commands:
+    description: Install and configure the Fossa CLI in your custom jobs.
+    usage:
+      version: 2.1
+      orbs:
+        fossa-cli: fossa/cli@x.y.z
+      jobs:
+        my-job:
+          executor: fossa-cli/default # or your own custom executor
+          steps:
+            - checkout
             - fossa-cli/setup
+            - run: echo "Run more commands here"
 
-  custom_fossa_usage:
+executors:
+  default:
     description: |
-      You can run any custom fossa-cli command that you wish. In the example
-      below we are running `fossa analyze` with the debug flag enabled.
-    usage:
-      version: 2.1
+      A basic linux environment. Override with your own Docker image if needed.
+    docker:
+    - image: <<parameters.image>>
+    parameters:
+      image:
+        default: cimg/base@2019.08-node
+        description: |
+          Select a custom Docker image. https://hub.docker.com/r/circleci/
+        type: string
 
-      orbs:
-        fossa-cli: fossa/cli@dev:alpha
-
-      workflows:
-        fossa-integration:
-          jobs:
-            - fossa-cli/custom:
-                custom-command:
-                  - fossa analyze --debug
+jobs:
+  analyze:
+    description: |
+      Analyze a project
+    executor: default
+    parameters:
+      save_artifact:
+        type: boolean
+        default: true
+        description: Saves an artifact with the results of the analysis.
+      debug:
+        type: boolean
+        default: false
+        description: Include the boolean flag.
+    steps:
+      - checkout
+      - setup
+      - run:
+          name: Fossa Analyze
+          command: |
+            mkdir -p /tmp/fossa/analyze
+            fossa analyze <<# parameters.debug >>--debug <</ parameters.debug >><<# parameters.save_artifact >>-o /tmp/fossa/analyze/fossa_results.txt<</ parameters.save_artifact >>
+      - when:
+          condition: << parameters.save_artifact >>
+          steps:
+            - store_artifacts:
+                path: /tmp/fossa/analyze
 
 commands:
   setup:
@@ -54,18 +91,3 @@ commands:
       - run:
           name: Analyze the project with fossa-cli and generate a dependency graph
           command: fossa analyze
-  custom:
-    description: |
-      Run any custom fossa-cli command (more instructions here: https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#cli-reference)
-    parameters:
-      custom-command:
-        description: |
-          Define any custom fossa-cli command.
-        type: string
-    steps:
-      - when:
-          condition: << parameters.custom-command >>
-          steps:
-            - run:
-                name: Run any custom fossa-cli command.
-                command: << parameters.custom-command >>

--- a/publish-alpha.sh
+++ b/publish-alpha.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# run like this:
-# bash publish-alpha.sh your-namespace/your-orb-name
-
-circleci config pack src > orb.yml
-circleci orb publish orb.yml "$1@dev:alpha"
-rm -rf orb.yml

--- a/replace-config.sh
+++ b/replace-config.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-rm -rf .circleci/config.yml
-mv config.yml .circleci

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,8 +1,0 @@
-version: 2.1
-
-description: >
-  # What will your orb allow users to do?
-  # Descriptions should be short, simple, and clear.
-
-orbs:
-  # if your orb will use any other orbs, you can import them here

--- a/src/commands/command.yml
+++ b/src/commands/command.yml
@@ -1,3 +1,0 @@
-description: >
-  # What will this command do?
-  # Descriptions should be short, simple, and clear.

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -1,3 +1,0 @@
-description: >
-  # What will this example document?
-  # Descriptions should be short, simple, and clear.

--- a/src/executors/executor.yml
+++ b/src/executors/executor.yml
@@ -1,3 +1,0 @@
-description: >
-  # What is this executor?
-  # Descriptions should be short, simple, and clear.

--- a/src/jobs/job.yml
+++ b/src/jobs/job.yml
@@ -1,3 +1,0 @@
-description: >
-  # What will this job do?
-  # Descriptions should be short, simple, and clear.


### PR DESCRIPTION
I have removed the “custom” command as it didn’t really serve to shorten anything for the end user. I then also added a job for “analyze” which I believe is what your original example set out to achieve. This is a job that can be added to a workflow which will checkout the users code, install the fossa CLI using your setup command, and then run “fossa analyze”. I added the ability to also save those results as an artifact and enable debugging based on some parameters. Saving to an artifact should be on by default.


Missing:
- Need to address authentication. Either by adding a parameter if fed to the CLI, or making a note withing the setup description.

- Check all description

Tasks:
- Test the orb.