### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -4,8 +4,10 @@ version: 2.1
 
 description: |
   This orb integrates open source licensing compliance and vulnerability checks into your CI/CD workflow.
-  Source - https://github.com/fossas/fossa-cli-orb
   Docs - https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#cli-reference
+display:
+  home_url: https://fossa.com/
+  source_url: https://github.com/fossas/fossa-cli-orb
 
 examples:
   analyze_job:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.